### PR TITLE
Fix clippy warnings, improve errors, bring to 2018 edition, update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,21 +9,24 @@ license = "WTFPL"
 repository = "https://github.com/tiborgats/scaleless_music"
 documentation = "https://tiborgats.github.io/scaleless_music"
 
+edition = "2018"
+
 [features]
-default = []
 # Optional backends
 be-portaudio = ["portaudio"]
 be-rsoundio = ["rsoundio", "rb"]
 be-sdl2 = ["sdl2"]
+default = []
 
 [dependencies]
-portaudio = { version = "0.7.0", optional = true }
-rsoundio = { version = "0.1.6", optional = true }
-rb = { version = "0.2.0", optional = true }
-sdl2 = { version = "0.25.0", optional = true }
 num = "0.1.36"
+portaudio = { version = "0.7.0", optional = true }
+rb = { version = "0.2.0", optional = true }
+rsoundio = { version = "0.1.6", optional = true }
+sdl2 = { version = "0.25.0", optional = true }
+thiserror = "1.0.26"
 
 [dev-dependencies]
-piston_window = "0.57.0"
-piston = "0.26.0"
 conrod = "0.46.0"
+piston = "0.26.0"
+piston_window = "0.57.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,14 @@ be-sdl2 = ["sdl2"]
 default = []
 
 [dependencies]
-num = "0.1.36"
+num = "0.4.0"
 portaudio = { version = "0.7.0", optional = true }
-rb = { version = "0.2.0", optional = true }
+rb = { version = "0.3.2", optional = true }
 rsoundio = { version = "0.1.6", optional = true }
-sdl2 = { version = "0.25.0", optional = true }
+sdl2 = { version = "0.34.5", optional = true }
 thiserror = "1.0.26"
 
 [dev-dependencies]
-conrod = "0.46.0"
-piston = "0.26.0"
-piston_window = "0.57.0"
+conrod = "0.62.1"
+piston = "0.53.0"
+piston_window = "0.120.0"

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -1,7 +1,8 @@
 #![feature(test)]
 
+use scaleless_music;
+
 extern crate test;
-extern crate scaleless_music;
 
 use scaleless_music::sound::*;
 use std::rc::Rc;
@@ -42,8 +43,8 @@ fn freqconst_vibrato(bencher: &mut Bencher) {
     let tempo = Tempo::new(120.0).unwrap();
     tempo.get_beats_per_second(0.0, &mut tempo_buffer);
     let frequency = FrequencyConst::new(440.0).unwrap();
-    let mut vibrato = Vibrato::new(BENCH_SAMPLE_RATE, NoteValue::new(1, 4).unwrap(), 1.125)
-        .unwrap();
+    let mut vibrato =
+        Vibrato::new(BENCH_SAMPLE_RATE, NoteValue::new(1, 4).unwrap(), 1.125).unwrap();
 
     bencher.iter(|| {
         frequency.get(0.0, None, &mut frequency_buffer).unwrap();
@@ -57,14 +58,18 @@ fn tremolo(bencher: &mut Bencher) {
     let mut amplitude_buffer: Vec<SampleCalc> = vec![1.0; BENCH_BUFFER_SIZE];
     let tempo = Tempo::new(120.0).unwrap();
     tempo.get_beats_per_second(0.0, &mut tempo_buffer);
-    let amplitude_rhythm = Tremolo::new_with_tempo(BENCH_SAMPLE_RATE,
-                                                   TimingOption::None,
-                                                   NoteValue::new(1, 4).unwrap(),
-                                                   1.2)
-        .unwrap();
+    let amplitude_rhythm = Tremolo::new_with_tempo(
+        BENCH_SAMPLE_RATE,
+        TimingOption::None,
+        NoteValue::new(1, 4).unwrap(),
+        1.2,
+    )
+    .unwrap();
 
     bencher.iter(|| {
-        amplitude_rhythm.apply_rhythmic(&tempo_buffer, &mut amplitude_buffer).unwrap();
+        amplitude_rhythm
+            .apply_rhythmic(&tempo_buffer, &mut amplitude_buffer)
+            .unwrap();
     });
 }
 
@@ -89,11 +94,13 @@ fn ampdec_overtone(bencher: &mut Bencher) {
     let amplitude = {
         let overtones_amplitude: Vec<SampleCalc> = vec![1.0, 0.5];
         let overtones_dec_rate: Vec<SampleCalc> = vec![1.0, 0.5];
-        AmplitudeDecayExpOvertones::new(BENCH_SAMPLE_RATE,
-                                        1,
-                                        &overtones_amplitude,
-                                        &overtones_dec_rate)
-            .unwrap()
+        AmplitudeDecayExpOvertones::new(
+            BENCH_SAMPLE_RATE,
+            1,
+            &overtones_amplitude,
+            &overtones_dec_rate,
+        )
+        .unwrap()
     };
 
     bencher.iter(|| {
@@ -109,22 +116,28 @@ fn timbre_freqconst_ampdec_overtones16(bencher: &mut Bencher) {
     let mut time: SampleCalc = 0.0;
     let frequency = FrequencyConst::new(440.0).unwrap();
     let amplitude = {
-        let overtones_amplitude: Vec<SampleCalc> = vec![10.0, 1.0, 1.0, 0.95, 0.9, 0.9, 0.86,
-                                                        0.83, 0.80, 0.78, 0.76, 0.74, 0.73, 0.72,
-                                                        0.71, 0.70];
-        let overtones_dec_rate: Vec<SampleCalc> = vec![1.0, 0.6, 0.5, 0.4, 0.35, 0.3, 0.28, 0.26,
-                                                       0.25, 0.24, 0.23, 0.22, 0.21, 0.1, 0.2, 0.2];
-        AmplitudeDecayExpOvertones::new(BENCH_SAMPLE_RATE,
-                                        15,
-                                        &overtones_amplitude,
-                                        &overtones_dec_rate)
-            .unwrap()
+        let overtones_amplitude: Vec<SampleCalc> = vec![
+            10.0, 1.0, 1.0, 0.95, 0.9, 0.9, 0.86, 0.83, 0.80, 0.78, 0.76, 0.74, 0.73, 0.72, 0.71,
+            0.70,
+        ];
+        let overtones_dec_rate: Vec<SampleCalc> = vec![
+            1.0, 0.6, 0.5, 0.4, 0.35, 0.3, 0.28, 0.26, 0.25, 0.24, 0.23, 0.22, 0.21, 0.1, 0.2, 0.2,
+        ];
+        AmplitudeDecayExpOvertones::new(
+            BENCH_SAMPLE_RATE,
+            15,
+            &overtones_amplitude,
+            &overtones_dec_rate,
+        )
+        .unwrap()
     };
     let timbre = Timbre::new(BENCH_SAMPLE_RATE, BENCH_BUFFER_SIZE, Rc::new(amplitude), 16).unwrap();
 
     bencher.iter(|| {
         frequency.get(time, None, &mut frequency_buffer).unwrap();
-        timbre.get(&frequency_buffer, &mut generator_buffer).unwrap();
+        timbre
+            .get(&frequency_buffer, &mut generator_buffer)
+            .unwrap();
         time += BENCH_BUFFER_TIME;
         // test::black_box(&mut generator_buffer);
     });
@@ -140,17 +153,21 @@ fn timbre_freqconst_ampdec_overtones4(bencher: &mut Bencher) {
     let amplitude = {
         let overtones_amplitude: Vec<SampleCalc> = vec![10.0, 1.0, 1.0, 0.95];
         let overtones_dec_rate: Vec<SampleCalc> = vec![1.0, 0.6, 0.5, 0.4];
-        AmplitudeDecayExpOvertones::new(BENCH_SAMPLE_RATE,
-                                        3,
-                                        &overtones_amplitude,
-                                        &overtones_dec_rate)
-            .unwrap()
+        AmplitudeDecayExpOvertones::new(
+            BENCH_SAMPLE_RATE,
+            3,
+            &overtones_amplitude,
+            &overtones_dec_rate,
+        )
+        .unwrap()
     };
     let timbre = Timbre::new(BENCH_SAMPLE_RATE, BENCH_BUFFER_SIZE, Rc::new(amplitude), 4).unwrap();
 
     bencher.iter(|| {
         frequency.get(time, None, &mut frequency_buffer).unwrap();
-        timbre.get(&frequency_buffer, &mut generator_buffer).unwrap();
+        timbre
+            .get(&frequency_buffer, &mut generator_buffer)
+            .unwrap();
         time += BENCH_BUFFER_TIME;
         // test::black_box(&mut generator_buffer);
     });
@@ -166,16 +183,19 @@ fn mixer4_timbre_freqconst_ampdec_overtones4(bencher: &mut Bencher) {
     let amplitude = Rc::new({
         let overtones_amplitude: Vec<SampleCalc> = vec![10.0, 1.0, 1.0, 0.95];
         let overtones_dec_rate: Vec<SampleCalc> = vec![1.0, 0.6, 0.5, 0.4];
-        AmplitudeDecayExpOvertones::new(BENCH_SAMPLE_RATE,
-                                        3,
-                                        &overtones_amplitude,
-                                        &overtones_dec_rate)
-            .unwrap()
+        AmplitudeDecayExpOvertones::new(
+            BENCH_SAMPLE_RATE,
+            3,
+            &overtones_amplitude,
+            &overtones_dec_rate,
+        )
+        .unwrap()
     });
-    let timbre1 = Rc::new(Timbre::new(BENCH_SAMPLE_RATE, BENCH_BUFFER_SIZE, amplitude.clone(), 4)
-        .unwrap());
+    let timbre1 =
+        Rc::new(Timbre::new(BENCH_SAMPLE_RATE, BENCH_BUFFER_SIZE, amplitude.clone(), 4).unwrap());
     let mixer = Mixer::new(BENCH_SAMPLE_RATE, BENCH_BUFFER_SIZE).unwrap();
-    mixer.add(Interval::new(1, 1).unwrap(), timbre1.clone(), 2.0)
+    mixer
+        .add(Interval::new(1, 1).unwrap(), timbre1.clone(), 2.0)
         .unwrap()
         .add(Interval::new(1, 2).unwrap(), timbre1.clone(), 3.0)
         .unwrap();

--- a/examples/instrument1.rs
+++ b/examples/instrument1.rs
@@ -155,7 +155,7 @@ fn main() {
                 println!("Pressed {:?}", button);
             }
         }
-        window.draw_2d(&event, |_c, g| {
+        window.draw_2d(&event, |_c, g, _| {
             clear([1.0, 1.0, 1.0, 1.0], g);
         });
     }

--- a/examples/instrument1.rs
+++ b/examples/instrument1.rs
@@ -5,15 +5,11 @@
 //! The keys from <kbd>Q</kbd> to <kbd>O</kbd> changes the frequency to be higher,
 //! the keys from <kbd>A</kbd> to <kbd>L</kbd> changes the frequency to be lower.
 /// Other keys play the previous frequency. To quit press <kbd>Esc</kbd>.
+use scaleless_music;
 
-extern crate scaleless_music;
-
-#[macro_use]
-extern crate conrod;
-extern crate piston_window;
-extern crate piston;
-
+use piston_window;
 use piston_window::*;
+
 use scaleless_music::sound::*;
 use std::rc::Rc;
 
@@ -40,16 +36,20 @@ impl InstrumentBasic {
     pub fn new(sample_rate: SampleCalc) -> SoundResult<InstrumentBasic> {
         let frequency1 = FrequencyConst::new(220.0)?;
         let amplitude = {
-            let overtones_amplitude: Vec<SampleCalc> = vec![10.0, 1.0, 1.0, 0.95, 0.9, 0.9, 0.86,
-                                                            0.83, 0.80, 0.78, 0.76, 0.74, 0.73,
-                                                            0.72, 0.71, 0.70];
-            let overtones_half_life: Vec<SampleCalc> = vec![1.0, 0.2, 0.1, 0.06, 0.04, 0.03, 0.02,
-                                                            0.015, 0.01, 0.008, 0.007, 0.006,
-                                                            0.005, 0.004, 0.002, 0.001];
-            AmplitudeDecayExpOvertones::new(sample_rate,
-                                            4,
-                                            &overtones_amplitude,
-                                            &overtones_half_life)?
+            let overtones_amplitude: Vec<SampleCalc> = vec![
+                10.0, 1.0, 1.0, 0.95, 0.9, 0.9, 0.86, 0.83, 0.80, 0.78, 0.76, 0.74, 0.73, 0.72,
+                0.71, 0.70,
+            ];
+            let overtones_half_life: Vec<SampleCalc> = vec![
+                1.0, 0.2, 0.1, 0.06, 0.04, 0.03, 0.02, 0.015, 0.01, 0.008, 0.007, 0.006, 0.005,
+                0.004, 0.002, 0.001,
+            ];
+            AmplitudeDecayExpOvertones::new(
+                sample_rate,
+                4,
+                &overtones_amplitude,
+                &overtones_half_life,
+            )?
         };
         let timbre1 = Timbre::new(sample_rate, BUFFER_SIZE_DEFAULT, Rc::new(amplitude), 4)?;
         Ok(InstrumentBasic {
@@ -81,7 +81,9 @@ impl SoundGenerator for InstrumentBasic {
     type Command = GeneratorCommand;
 
     fn get_samples(&mut self, sample_count: usize, result: &mut Vec<SampleCalc>) {
-        self.frequency1.get(self.time, None, &mut self.frequency1_buffer).unwrap();
+        self.frequency1
+            .get(self.time, None, &mut self.frequency1_buffer)
+            .unwrap();
         self.timbre1.get(&self.frequency1_buffer, result).unwrap();
         self.time += sample_count as SampleCalc / self.sample_rate;
     }
@@ -115,7 +117,10 @@ impl SoundGenerator for InstrumentBasic {
             GeneratorCommand::Mute => {
                 let _ = self.change_frequency(1, 1);
             }
-            GeneratorCommand::FrequencyMultiple { numerator, denominator } => {
+            GeneratorCommand::FrequencyMultiple {
+                numerator,
+                denominator,
+            } => {
                 let _ = self.change_frequency(numerator, denominator);
             }
         }
@@ -124,8 +129,9 @@ impl SoundGenerator for InstrumentBasic {
 
 fn main() {
     println!("scaleless_music v{} example", env!("CARGO_PKG_VERSION"));
-    let sound_generator = Box::new(InstrumentBasic::new(48000.0)
-        .expect("InstrumentBasic construction shouldn't fail."));
+    let sound_generator = Box::new(
+        InstrumentBasic::new(48000.0).expect("InstrumentBasic construction shouldn't fail."),
+    );
     let mut sound = SoundInterface::new(48000, BUFFER_SIZE_DEFAULT, 2, sound_generator)
         .expect("SoundInterface construction shouldn't fail.");
 
@@ -142,7 +148,8 @@ fn main() {
     while let Some(event) = window.next() {
         if let Some(button) = event.press_args() {
             if let Button::Keyboard(key) = button {
-                sound.send_command(GeneratorCommand::Keypress { key: key })
+                sound
+                    .send_command(GeneratorCommand::Keypress { key: key })
                     .expect("send_command failed.");
             } else {
                 println!("Pressed {:?}", button);

--- a/examples/instrument_overtone.rs
+++ b/examples/instrument_overtone.rs
@@ -176,7 +176,7 @@ fn main() {
                 println!("Pressed {:?}", button);
             }
         }
-        window.draw_2d(&event, |_c, g| {
+        window.draw_2d(&event, |_c, g, _| {
             clear([1.0, 1.0, 1.0, 1.0], g);
         });
     }

--- a/examples/instrument_overtone.rs
+++ b/examples/instrument_overtone.rs
@@ -2,12 +2,9 @@
 //! The tone is a very simple function (nothing like a real instrument). It's purpose is
 //! only testing.
 //! See also: [Overtone flute](https://en.wikipedia.org/wiki/Overtone_flute)
-extern crate scaleless_music;
+use scaleless_music;
 
-#[macro_use]
-extern crate conrod;
-extern crate piston_window;
-extern crate piston;
+use piston_window;
 
 use piston_window::*;
 use scaleless_music::sound::*;
@@ -36,27 +33,40 @@ impl InstrumentBasic {
     pub fn new(sample_rate: SampleCalc) -> SoundResult<InstrumentBasic> {
         let frequency1 = Rc::new(FrequencyConst::new(110.0)?);
         let amplitude = {
-            let overtones_amplitude: Vec<SampleCalc> = vec![10.0, 1.0, 1.0, 0.95, 0.9, 0.9, 0.86,
-                                                            0.83, 0.80, 0.78, 0.76, 0.74, 0.73,
-                                                            0.72, 0.71, 0.70];
-            let overtones_half_life: Vec<SampleCalc> = vec![1.0, 0.2, 0.1, 0.06, 0.04, 0.03, 0.02,
-                                                            0.015, 0.01, 0.008, 0.007, 0.006,
-                                                            0.005, 0.004, 0.002, 0.001];
-            AmplitudeDecayExpOvertones::new(sample_rate,
-                                            4,
-                                            &overtones_amplitude,
-                                            &overtones_half_life)?
+            let overtones_amplitude: Vec<SampleCalc> = vec![
+                10.0, 1.0, 1.0, 0.95, 0.9, 0.9, 0.86, 0.83, 0.80, 0.78, 0.76, 0.74, 0.73, 0.72,
+                0.71, 0.70,
+            ];
+            let overtones_half_life: Vec<SampleCalc> = vec![
+                1.0, 0.2, 0.1, 0.06, 0.04, 0.03, 0.02, 0.015, 0.01, 0.008, 0.007, 0.006, 0.005,
+                0.004, 0.002, 0.001,
+            ];
+            AmplitudeDecayExpOvertones::new(
+                sample_rate,
+                4,
+                &overtones_amplitude,
+                &overtones_half_life,
+            )?
         };
-        let timbre1 =
-            Rc::new(Timbre::new(sample_rate, BUFFER_SIZE_DEFAULT, Rc::new(amplitude), 4)?);
+        let timbre1 = Rc::new(Timbre::new(
+            sample_rate,
+            BUFFER_SIZE_DEFAULT,
+            Rc::new(amplitude),
+            4,
+        )?);
         let amplitude = {
-            let overtones_amplitude: Vec<SampleCalc> = vec![1.0, 0.1, 0.1, 0.1, 0.2, 0.5, 0.1,
-                                                            0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1,
-                                                            0.1, 0.1, 0.1, 0.1, 0.1, 0.1];
+            let overtones_amplitude: Vec<SampleCalc> = vec![
+                1.0, 0.1, 0.1, 0.1, 0.2, 0.5, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1,
+                0.1, 0.1, 0.1, 0.1,
+            ];
             AmplitudeConstOvertones::new(sample_rate, 4, &overtones_amplitude)?
         };
-        let timbre2 =
-            Rc::new(Timbre::new(sample_rate, BUFFER_SIZE_DEFAULT, Rc::new(amplitude), 4)?);
+        let timbre2 = Rc::new(Timbre::new(
+            sample_rate,
+            BUFFER_SIZE_DEFAULT,
+            Rc::new(amplitude),
+            4,
+        )?);
         let mixer = Rc::new(Mixer::new(sample_rate, BUFFER_SIZE_DEFAULT)?);
         mixer.add(Interval::new(1, 1)?, timbre1, 4.0)?;
         mixer.add(Interval::new(1, 1)?, timbre2, 1.0)?;
@@ -86,7 +96,9 @@ impl SoundGenerator for InstrumentBasic {
     type Command = GeneratorCommand;
 
     fn get_samples(&mut self, sample_count: usize, result: &mut Vec<SampleCalc>) {
-        self.frequency1.get(self.time, None, &mut self.frequency1_buffer).unwrap();
+        self.frequency1
+            .get(self.time, None, &mut self.frequency1_buffer)
+            .unwrap();
         self.mixer.get(&self.frequency1_buffer, result).unwrap();
         self.time += sample_count as SampleCalc / self.sample_rate;
     }
@@ -120,7 +132,10 @@ impl SoundGenerator for InstrumentBasic {
             GeneratorCommand::Mute => {
                 let _ = self.change_frequency(1, 1);
             }
-            GeneratorCommand::FrequencyMultiple { numerator, denominator } => {
+            GeneratorCommand::FrequencyMultiple {
+                numerator,
+                denominator,
+            } => {
                 let _ = self.change_frequency(numerator, denominator);
             }
         }
@@ -131,10 +146,13 @@ impl SoundGenerator for InstrumentBasic {
 unsafe impl Send for InstrumentBasic {} // this is a temporary ugly workaround for the SDL2 backend
 
 fn main() {
-    println!("scaleless_music v{} example: overtone instrument\n",
-             env!("CARGO_PKG_VERSION"));
-    let sound_generator = Box::new(InstrumentBasic::new(48000.0)
-        .expect("InstrumentBasic construction shouldn't fail."));
+    println!(
+        "scaleless_music v{} example: overtone instrument\n",
+        env!("CARGO_PKG_VERSION")
+    );
+    let sound_generator = Box::new(
+        InstrumentBasic::new(48000.0).expect("InstrumentBasic construction shouldn't fail."),
+    );
     let mut sound = SoundInterface::new(48000, BUFFER_SIZE_DEFAULT, 2, sound_generator)
         .expect("SoundInterface construction shouldn't fail.");
 
@@ -151,7 +169,8 @@ fn main() {
     while let Some(event) = window.next() {
         if let Some(button) = event.press_args() {
             if let Button::Keyboard(key) = button {
-                sound.send_command(GeneratorCommand::Keypress { key: key })
+                sound
+                    .send_command(GeneratorCommand::Keypress { key: key })
                     .expect("send_command failed.");
             } else {
                 println!("Pressed {:?}", button);

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,1 @@
-write_mode = "Overwrite"
 reorder_imports = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,30 +20,50 @@
 //! ```
 //!
 #![doc(html_root_url = "https://tiborgats.github.io/music/")]
-
-#![forbid(bad_style, exceeding_bitshifts, mutable_transmutes, no_mangle_const_items,
-    unknown_crate_types)]
-#![deny(deprecated, improper_ctypes, missing_docs,
-    non_shorthand_field_patterns, overflowing_literals, plugin_as_library,
-    private_no_mangle_fns, private_no_mangle_statics, stable_features, unconditional_recursion,
-    unknown_lints, unsafe_code, unused, unused_allocation, unused_attributes,
-    unused_comparisons, unused_features, unused_parens, while_true)]
-#![warn(trivial_casts, trivial_numeric_casts, unused_extern_crates, unused_import_braces,
-    unused_qualifications, unused_results)]
+#![forbid(
+    bad_style,
+    arithmetic_overflow,
+    mutable_transmutes,
+    no_mangle_const_items,
+    unknown_crate_types
+)]
+#![deny(
+    deprecated,
+    improper_ctypes,
+    missing_docs,
+    non_shorthand_field_patterns,
+    overflowing_literals,
+    stable_features,
+    unconditional_recursion,
+    unknown_lints,
+    unsafe_code,
+    unused,
+    unused_allocation,
+    unused_attributes,
+    unused_comparisons,
+    unused_features,
+    unused_parens,
+    while_true
+)]
+#![warn(
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_extern_crates,
+    unused_import_braces,
+    unused_qualifications,
+    unused_results
+)]
 
 // #![feature(question_mark)]
 
 #[cfg(feature = "be-portaudio")]
-extern crate portaudio;
+use portaudio;
 #[cfg(feature = "be-rsoundio")]
-extern crate rsoundio;
+use rb;
 #[cfg(feature = "be-rsoundio")]
-extern crate rb;
+use rsoundio;
 #[cfg(feature = "be-sdl2")]
-extern crate sdl2;
-
-
-extern crate num;
+use sdl2;
 
 /// Basic sound synthesizer routines.
 pub mod sound;

--- a/src/sound/backend_rsoundio.rs
+++ b/src/sound/backend_rsoundio.rs
@@ -1,4 +1,4 @@
-use rb::{RB, RbConsumer, RbProducer, SpscRb};
+use rb::{RbConsumer, RbProducer, SpscRb, RB};
 use sound::*;
 use std::sync::mpsc::Sender;
 

--- a/src/sound/errors.rs
+++ b/src/sound/errors.rs
@@ -1,125 +1,92 @@
 #[cfg(feature = "be-portaudio")]
-use sound::backend_portaudio::*;
+use crate::sound::backend_portaudio::*;
 #[cfg(feature = "be-rsoundio")]
-use sound::backend_rsoundio::*;
+use crate::sound::backend_rsoundio::*;
 #[cfg(feature = "be-sdl2")]
-use sound::backend_sdl2::*;
-use std::{error, fmt};
+use crate::sound::backend_sdl2::*;
+
+use thiserror::Error;
 
 /// Return type for the sound module functions.
 pub type SoundResult<T> = Result<T, Error>;
 
-// TODO: use [error-chain](https://github.com/brson/error-chain)
-// or [quick-error](https://github.com/tailhook/quick-error)
-
 /// Error types of the sound module.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Error)]
 pub enum Error {
-    /// Sound output backend error.
     #[cfg(any(feature = "be-portaudio", feature = "be-rsoundio", feature = "be-sdl2"))]
-    Backend(BackendError),
+    /// Sound output backend error.
+    #[error("Backend error: {0}")]
+    Backend(#[from] BackendError),
     /// Invalid sample rate.
+    #[error("Invalid sample rate")]
     SampleRateInvalid,
     /// Invalid buffer size for the given sample count.
+    #[error("Incorrect buffer size")]
     BufferSize,
     /// Overtone count does not match the reserved array size.
+    #[error("Invalid overtone count")]
     OvertoneCountInvalid,
     /// Numerator cannot be 0, because frequencies can not be 0.
+    #[error("Invalid numerator")]
     NumeratorInvalid,
     /// Denominator cannot be 0 (division by zero error).
+    #[error("Invalid denominator")]
     DenominatorInvalid,
     /// The frequency is below the hearing range.
+    #[error("Frequency is below the hearing range")]
     FrequencyTooLow,
     /// The frequency exceeds the hearing range.
+    #[error("Frequency exceeds the hearing range")]
     FrequencyTooHigh,
     /// Frequency can not be zero or negative.
+    #[error("Frequency can not be zero or negative")]
     FrequencyInvalid,
     /// This frequency function is a source, it can not use an input frequency buffer.
+    #[error("Input frequency buffer can not be used")]
     FrequencySource,
     /// A rate must be positive.
+    #[error("Invalid rate")]
     RateInvalid,
     /// Amplitude cannot be negative.
+    #[error("Invalid amplitude")]
     AmplitudeInvalid,
     /// Amplitude change time is not positive.
+    #[error("Invalid amplitude change time")]
     AmplitudeTimeInvalid,
     /// Amplitude change rate is out of the range allowed for the given function.
+    #[error("Invalid amplitude decay rate")]
     AmplitudeRateInvalid,
     /// A time period must be positive.
+    #[error("Invalid period")]
     PeriodInvalid,
     /// A time duration must be positive.
+    #[error("Invalid duration")]
     DurationInvalid,
     /// Channel of the given number does not exist.
+    #[error("Invalid channel")]
     ChannelInvalid,
     /// Beats per minute must be positive.
+    #[error("Beats per minute must be positive")]
     TempoInvalid,
     /// Timing option does not match the method.
+    #[error("Invalid timing option")]
     TimingInvalid,
     /// The selected progress option is invalid for this case.
+    #[error("Invalid progress option")]
     ProgressInvalid,
     /// Progress is finished.
+    #[error("Progress completed")]
     ProgressCompleted,
     /// The number of items completed in an unfinished buffer operation.
+    #[error("The number of items completed in an unfinished buffer operation: {0}")]
     ItemsCompleted(usize),
     /// The Sequence has no items.
+    #[error("Sequence has no items")]
     SequenceEmpty,
     /// Item at the given index does not exist.
+    #[error("The item does not exist")]
     ItemInvalid,
     /// Overflow occured during calculations.
+    #[error("Overflow")]
     Overflow,
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use std::error::Error;
-        f.write_str(self.description())
-    }
-}
-
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        use self::Error::*;
-        match *self {
-            #[cfg(any(feature = "be-portaudio", feature = "be-rsoundio", feature = "be-sdl2"))]
-            Backend(ref err) => err.description(),
-            SampleRateInvalid => "invalid sample rate",
-            BufferSize => "incorrect buffer size",
-            OvertoneCountInvalid => "invalid overtone count",
-            NumeratorInvalid => "invalid numerator",
-            DenominatorInvalid => "invalid denominator",
-            FrequencyTooLow => "frequency is below the hearing range",
-            FrequencyTooHigh => "frequency exceeds the hearing range",
-            FrequencyInvalid => "frequency can not be zero or negative",
-            FrequencySource => "input frequency buffer can not be used",
-            RateInvalid => "invalid rate",
-            AmplitudeInvalid => "invalid amplitude",
-            AmplitudeTimeInvalid => "invalid amplitude change time",
-            AmplitudeRateInvalid => "invalid amplitude decay rate",
-            PeriodInvalid => "invalid period",
-            DurationInvalid => "invalid duration",
-            ChannelInvalid => "invalid channel",
-            TempoInvalid => "beats per minute must be positive",
-            TimingInvalid => "invalid timing option",
-            ProgressInvalid => "invalid progress option",
-            ProgressCompleted => "progress completed",
-            ItemsCompleted(_) => "",
-            SequenceEmpty => "sequence has no items",
-            ItemInvalid => "the item does not exist",
-            Overflow => "overflow",
-        }
-    }
-
-    fn cause(&self) -> Option<&error::Error> {
-        match *self {
-            #[cfg(any(feature = "be-portaudio", feature = "be-rsoundio", feature = "be-sdl2"))]
-            self::Error::Backend(ref err) => Some(err),
-            _ => None,
-        }
-    }
-}
-
-#[cfg(any(feature = "be-portaudio", feature = "be-rsoundio", feature = "be-sdl2"))]
-impl From<BackendError> for Error {
-    fn from(e: BackendError) -> Self {
-        Error::Backend(e)
-    }
 }

--- a/src/sound/interval.rs
+++ b/src/sound/interval.rs
@@ -1,5 +1,5 @@
+use crate::sound::*;
 use num::*;
-use sound::*;
 use std::fmt;
 use std::ops::{Div, Mul};
 
@@ -146,10 +146,11 @@ impl Interval {
     }
 
     /// Change a frequency according to the interval.
-    pub fn transpose(&self,
-                     base_frequency: &[SampleCalc],
-                     result: &mut [SampleCalc])
-                     -> SoundResult<()> {
+    pub fn transpose(
+        &self,
+        base_frequency: &[SampleCalc],
+        result: &mut [SampleCalc],
+    ) -> SoundResult<()> {
         if base_frequency.len() != result.len() {
             return Err(Error::BufferSize);
         }
@@ -170,9 +171,11 @@ impl Mul for Interval {
     type Output = Interval;
 
     fn mul(self, rhs: Interval) -> Interval {
-        let mut interval = Interval::default();
-        interval.numerator = self.numerator * rhs.numerator;
-        interval.denominator = self.denominator * rhs.denominator;
+        let mut interval = Interval {
+            numerator: self.numerator * rhs.numerator,
+            denominator: self.denominator * rhs.denominator,
+            ..Default::default()
+        };
         interval.reduce();
         interval.ratio = interval.numerator as SampleCalc / interval.denominator as SampleCalc;
         interval.reciprocal = interval.denominator as SampleCalc / interval.numerator as SampleCalc;
@@ -184,9 +187,11 @@ impl Div for Interval {
     type Output = Interval;
 
     fn div(self, rhs: Interval) -> Interval {
-        let mut interval = Interval::default();
-        interval.numerator = self.numerator * rhs.denominator;
-        interval.denominator = self.denominator * rhs.numerator;
+        let mut interval = Interval {
+            numerator: self.numerator * rhs.denominator,
+            denominator: self.denominator * rhs.numerator,
+            ..Default::default()
+        };
         interval.reduce();
         interval.ratio = interval.numerator as SampleCalc / interval.denominator as SampleCalc;
         interval.reciprocal = interval.denominator as SampleCalc / interval.numerator as SampleCalc;

--- a/src/sound/mod.rs
+++ b/src/sound/mod.rs
@@ -1,23 +1,23 @@
-/// Error messages.
-pub mod errors;
-/// Frequency interval.
-pub mod interval;
-/// Fuctions which provide frequency changes.
-pub mod frequency;
 /// Fuctions which provide amplitude changes.
 pub mod amplitude;
 /// Fuctions which provide amplitude changes for overtones also.
 pub mod amplitude_overtones;
-/// Fuctions which provide complete waveforms.
-pub mod wave;
-/// Rhythm section.
-pub mod rhythm;
-/// Time and tempo based progress measurement.
-pub mod progress;
-/// Timing for the duration of sound components.
-pub mod timing;
+/// Error messages.
+pub mod errors;
+/// Fuctions which provide frequency changes.
+pub mod frequency;
+/// Frequency interval.
+pub mod interval;
 /// Musical note structures.
 pub mod note;
+/// Time and tempo based progress measurement.
+pub mod progress;
+/// Rhythm section.
+pub mod rhythm;
+/// Timing for the duration of sound components.
+pub mod timing;
+/// Fuctions which provide complete waveforms.
+pub mod wave;
 
 /// [`PortAudio`](https://github.com/RustAudio/rust-portaudio) backend for sound playback.
 #[cfg(feature = "be-portaudio")]
@@ -98,11 +98,12 @@ pub trait SoundStructure: HasTimer {
 /// A structure of music.
 pub trait MusicStructure {
     /// Returns the calculated samples in the `result` buffer.
-    fn get(&self,
-           base_tempo: &[SampleCalc],
-           base_frequency: &[SampleCalc],
-           result: &mut [SampleCalc])
-           -> SoundResult<()>;
+    fn get(
+        &self,
+        base_tempo: &[SampleCalc],
+        base_frequency: &[SampleCalc],
+        result: &mut [SampleCalc],
+    ) -> SoundResult<()>;
 }
 
 /// Calculates the period of one sample for the given sample rate.
@@ -111,6 +112,6 @@ pub fn get_sample_time(sample_rate: SampleCalc) -> SoundResult<SampleCalc> {
     if sample_rate < 1.0 {
         Err(Error::SampleRateInvalid)
     } else {
-        Ok((1.0 / sample_rate))
+        Ok(1.0 / sample_rate)
     }
 }

--- a/src/sound/note.rs
+++ b/src/sound/note.rs
@@ -1,6 +1,6 @@
-use sound::*;
-use std::rc::Rc;
+use crate::sound::*;
 use std::cell::RefCell;
+use std::rc::Rc;
 
 /// Musical note.
 #[derive(Clone)]
@@ -17,19 +17,12 @@ pub struct Note {
     /// It is used for the syncronization of some effects (e.g. vibrato, tremolo).
     tempo: Tempo,
     /// Sound structure.
-    sound: Rc<SoundStructure>,
+    sound: Rc<dyn SoundStructure>,
     volume_relative: SampleCalc,
     volume_normalized: SampleCalc,
     frequency_buffer: RefCell<Vec<SampleCalc>>,
     wave_buffer: RefCell<Vec<SampleCalc>>,
 }
-
-
-
-
-
-
-
 
 /// Sequence of musical notes.
 #[doc(hidden)]
@@ -43,18 +36,19 @@ impl NoteSequence {
     /// custom constructor
     pub fn new(buffer_size: usize) -> SoundResult<NoteSequence> {
         Ok(NoteSequence {
-            buffer_size: buffer_size,
+            buffer_size,
             notes: RefCell::new(Vec::new()),
         })
     }
 
     /// Add a new note to the sequence.
-    pub fn add(&self,
-               // interval: Interval,
-               // sound: Rc<SoundStructure>,
-               duration: SampleCalc,
-               volume: SampleCalc)
-               -> SoundResult<&NoteSequence> {
+    pub fn add(
+        &self,
+        // interval: Interval,
+        // sound: Rc<SoundStructure>,
+        duration: SampleCalc,
+        volume: SampleCalc,
+    ) -> SoundResult<&NoteSequence> {
         if duration <= 0.0 {
             return Err(Error::PeriodInvalid);
         }

--- a/src/sound/rhythm.rs
+++ b/src/sound/rhythm.rs
@@ -1,5 +1,5 @@
+use crate::sound::*;
 use num::*;
-use sound::*;
 use std::fmt;
 use std::ops::{Add, Mul};
 
@@ -7,12 +7,12 @@ use std::ops::{Add, Mul};
 /// [RFC #1465](https://github.com/rust-lang/rfcs/pull/1465)
 // https://github.com/crumblingstatue/try_opt
 macro_rules! try_opt {
-    ($e:expr) =>(
+    ($e:expr) => {
         match $e {
             Some(v) => v,
             None => return None,
         }
-    )
+    };
 }
 
 /// The `TempoProvider` trait is used to provide tempo.
@@ -50,7 +50,7 @@ impl Tempo {
         let beat_duration = 60.0 / beats_per_minute;
         Ok(Tempo {
             beats_per_second: beats_per_minute / 60.0,
-            beat_duration: beat_duration,
+            beat_duration,
         })
     }
 
@@ -114,22 +114,23 @@ pub struct TempoChangeLinear {
 // TODO: build pattern for the possibility to use different input variable combinations
 impl TempoChangeLinear {
     /// custom constructor
-    pub fn new(sample_rate: SampleCalc,
-               tempo_start: Tempo,
-               tempo_end: Tempo,
-               duration: SampleCalc)
-               -> SoundResult<TempoChangeLinear> {
+    pub fn new(
+        sample_rate: SampleCalc,
+        tempo_start: Tempo,
+        tempo_end: Tempo,
+        duration: SampleCalc,
+    ) -> SoundResult<TempoChangeLinear> {
         let sample_time = get_sample_time(sample_rate)?;
-        let beat_duration_change_rate = (tempo_end.beat_duration - tempo_start.beat_duration) /
-                                        duration;
+        let beat_duration_change_rate =
+            (tempo_end.beat_duration - tempo_start.beat_duration) / duration;
         let bps_change_rate = -1.0 / beat_duration_change_rate;
         Ok(TempoChangeLinear {
-            sample_time: sample_time,
-            tempo_start: tempo_start,
-            tempo_end: tempo_end,
-            duration: duration,
-            beat_duration_change_rate: beat_duration_change_rate,
-            bps_change_rate: bps_change_rate,
+            sample_time,
+            tempo_start,
+            tempo_end,
+            duration,
+            beat_duration_change_rate,
+            bps_change_rate,
         })
     }
     /// Sets duration calculated from the given note value.
@@ -241,7 +242,6 @@ impl NoteValue {
     }
 }
 
-
 impl Add for NoteValue {
     type Output = NoteValue;
 
@@ -260,11 +260,15 @@ impl Add for NoteValue {
 
 impl CheckedAdd for NoteValue {
     fn checked_add(&self, v: &Self) -> Option<Self> {
-        let lowest_common_multiple = try_opt!(self.denominator
+        let lowest_common_multiple = try_opt!(self
+            .denominator
             .checked_mul(v.denominator / self.denominator.gcd(&v.denominator)));
-        let n1 = try_opt!(self.numerator
+        let n1 = try_opt!(self
+            .numerator
             .checked_mul(lowest_common_multiple / self.denominator));
-        let n2 = try_opt!(v.numerator.checked_mul(lowest_common_multiple / v.denominator));
+        let n2 = try_opt!(v
+            .numerator
+            .checked_mul(lowest_common_multiple / v.denominator));
         let n = try_opt!(n1.checked_add(n2));
         Some(NoteValue {
             numerator: n,


### PR DESCRIPTION
As the title says: housekeeping tasks for bringing this awesome lib up to date for now. I pretty much followed clippy. For the error messages, I added `thiserror`.
The benches still run, but I cannot run the example applications - they panic, but did so before too...
Let me know what you think and if I can do anything else for this PR :)